### PR TITLE
Companies page: clasificando por servicios

### DIFF
--- a/src/front/js/component/companyCard.js
+++ b/src/front/js/component/companyCard.js
@@ -30,7 +30,7 @@ export const CompanyCard = ({company}) => {
             <div className="col-4 p-3"> 
                 <div className="card rounded-2 shadow"> 
                     <div className="card-header border-0 bg-white rounded-5 rounded-bottom"> 
-                        <img className="img-fluid object-fit-contain rounded mx-auto d-block" src={company.logo} alt={'logo: ' + company.logo} style={{height:'10vh'}} /> 
+                        <img className="img-fluid object-fit-contain rounded mx-auto d-block" src={'../'+company.logo} alt={'logo: ' + company.logo} style={{height:'10vh'}} /> 
                     </div> 
                     <div className="card-body bg-light pt-0 rounded-5 rounded-top rounded-top-0"> 
                         <div className="d-flex justify-content-between">

--- a/src/front/js/component/companyCard.js
+++ b/src/front/js/component/companyCard.js
@@ -19,35 +19,30 @@ export const CompanyCard = ({company}) => {
         window.location.href = "/info-empresa";
     };
 
-
     const { actions } = useContext(Context);
     const [isFavorite, setIsFavorite] = useState(false);
 
-    
-
     return (
         <>
-            <div className="col-4 p-3"> 
-                <div className="card rounded-2 shadow"> 
-                    <div className="card-header border-0 bg-white rounded-5 rounded-bottom"> 
-                        <img className="img-fluid object-fit-contain rounded mx-auto d-block" src={'../'+company.logo} alt={'logo: ' + company.logo} style={{height:'10vh'}} /> 
-                    </div> 
-                    <div className="card-body bg-light pt-0 rounded-5 rounded-top rounded-top-0"> 
-                        <div className="d-flex justify-content-between">
-                            <div className="my-auto">
-                                <h5 className="card-title fw-bold m-0 pt-2 text-start">{company.nombre}</h5> 
-                                <p className="card-text text-success fw-bold text-start">{company.pais}</p> 
-                            </div>
-                            <div className="fs-1 rounded-pill icon-hover clickable" onClick={() => handleAddFavorite(company, actions, isFavorite, setIsFavorite)}>
-                            <i className={isFavorite ? "fa-solid fa-heart text-success" : "fa-regular fa-heart"} />
-                            </div>
-                        </div>
-
-                        <p className="card-text text-secondary text-start">Grown in {company.ubicacion}</p> 
-                        <button className="btn btn-success rounded-pill float-start" onClick={navigateToQuienesSomos}>info</button>
-                    </div> 
+            <div className="card rounded-2 shadow"> 
+                <div className="card-header border-0 bg-white rounded-2 rounded-bottom"> 
+                    <img className="img-fluid object-fit-contain rounded mx-auto d-block" src={'../'+company.logo} alt={'logo: ' + company.logo} style={{height:'10vh'}} /> 
                 </div> 
-            </div>
+                <div className="card-body bg-light pt-0 rounded-2 rounded-top rounded-top-0"> 
+                    <div className="d-flex justify-content-between">
+                        <div className="my-auto">
+                            <h5 className="card-title fw-bold m-0 pt-2 text-start">{company.nombre}</h5> 
+                            <p className="card-text text-success fw-bold text-start">{company.pais}</p> 
+                        </div>
+                        <div className="fs-1 rounded-pill icon-hover clickable" onClick={() => handleAddFavorite(company, actions, isFavorite, setIsFavorite)}>
+                            <i className={isFavorite ? "fa-solid fa-heart text-success" : "fa-regular fa-heart"} />
+                        </div>
+                    </div>
+
+                    <p className="card-text text-secondary text-start">Grown in {company.ubicacion}</p> 
+                    <button className="btn btn-success rounded-pill float-start" onClick={navigateToQuienesSomos}>info</button>
+                </div> 
+            </div> 
         </>
     )
 };

--- a/src/front/js/component/companyCarousel.js
+++ b/src/front/js/component/companyCarousel.js
@@ -3,7 +3,7 @@ import { CompanyCard } from "../component/companyCard";
 import { Context } from '../store/appContext';
 
 
-export const CompanyCarousel = ({sector}) => {
+export const CompanyCarousel = ({sector, isGrid}) => {
     // App Store
     const { store } = useContext(Context);
     const sectorCompanies = store.companies[sector];
@@ -23,26 +23,74 @@ export const CompanyCarousel = ({sector}) => {
         return { transform: `translateX(${offset}%)` }; 
     };
 
+    const getSectorImage = (sectorId) => {
+        switch(sectorId){
+            case 'Packaging':
+                return <img className="imgservicios" src="../packaging-sostenible.webp" alt="img-packaging" />;
+            case 'Transporte':
+                return <img className="imgservicios" src="../furgonetas-w.webp" alt="img-transporte" />;
+            case 'Gestión de Residuos':
+                return <img className="imgservicios" src="../1533057826357.jpeg" alt="img-gestion-residuos" />;
+            default:
+                console.log('El parametro recibido no es correcto.')
+                return undefined;
+        }
+    }
+
     return (
         <>
-            <h1 className="text-start fw-normal fs-5 mb-0">EMPRESAS DE {sector.toUpperCase()}</h1>
-            <div className="company-carousel" style={{ width: '100%', overflow: 'hidden' }}> 
-                <div className="company-carousel-inner" style={{ display: 'flex', transition: 'transform 0.5s ease', ...getTransformStyle() }}> 
-                    {
-                        sectorCompanies ? (
-                                sectorCompanies.map((company, index) => (
-                                    <CompanyCard key={index} company={company} />
+            <h1 className="text-start fw-normal fs-5 mb-0 border-bottom">EMPRESAS DE {sector.toUpperCase()}</h1>
+            {
+                isGrid ? (
+                    <>
+                        <div className="text-center">
+                            <div className="imgcontainer p-3" style={{height:'25vh', width: '100%'}}> 
+                                {getSectorImage(sector)}
+                            </div> 
+                        </div>
+                        <div className="container rounded-2 shadow" style={{ width: '100%'/*, height:'60vh', overflowY: 'auto'*/ }}> 
+                            <div className="row row-cols-auto">
+                            {
+                                sectorCompanies ? (
+                                        sectorCompanies.map((company, index) => (
+                                            <div className="col-4 p-3"> 
+                                                <CompanyCard key={index} company={company} />
+                                            </div>
+                                        )
+                                    )
                                 )
-                            )
-                        )
-                        : (
-                            <p>No se encontraron empresas de {sector}.</p>
-                        )
-                    } 
-                </div> 
-                <button className="company-carousel-button left" onClick={() => handleMoveCarousel(-1)}>&#10094;</button> 
-                <button className="company-carousel-button right" onClick={() => handleMoveCarousel(1)}>&#10095;</button> 
-            </div>
+                                : 
+                                (
+                                    <p>No se encontraron empresas de {sector}.</p>
+                                )
+                            } 
+                            </div>
+                        </div>
+                    </>
+                )
+                :
+                (
+                    <div className="company-carousel" style={{ width: '100%', overflow: 'hidden' }}> 
+                        <div className="company-carousel-inner" style={{ display: 'flex', transition: 'transform 0.5s ease', ...getTransformStyle() }}> 
+                            {
+                                sectorCompanies ? (
+                                        sectorCompanies.map((company, index) => (
+                                            <div className="col-4 p-3"> 
+                                                <CompanyCard key={index} company={company} />
+                                            </div>
+                                        )
+                                    )
+                                )
+                                : (
+                                    <p>No se encontraron empresas de {sector}.</p>
+                                )
+                            } 
+                        </div> 
+                        <button className="company-carousel-button left" onClick={() => handleMoveCarousel(-1)}>&#10094;</button> 
+                        <button className="company-carousel-button right" onClick={() => handleMoveCarousel(1)}>&#10095;</button> 
+                    </div>
+                )
+            }
         </>
     )
 };

--- a/src/front/js/component/navbar.js
+++ b/src/front/js/component/navbar.js
@@ -45,7 +45,7 @@ export const Navbar = () => {
                 </li>
               )}
               <li className="nav-item"><Link to={"/servicios"} className="nav-link text-black">Servicios</Link></li>
-              <li className="nav-item"><Link to={"/companies"} className="nav-link text-black">Empresas</Link></li>
+              <li className="nav-item"><Link to={"/companies/all"} className="nav-link text-black">Empresas</Link></li>
               <li className="nav-item"><Link to={"/quienes-somos"} className="nav-link text-black">Quiénes somos</Link></li>
               <li className="nav-item"><Link to={"/contacto"} className="nav-link text-black">Contacto</Link></li>
             </ul>

--- a/src/front/js/component/servicesRow.js
+++ b/src/front/js/component/servicesRow.js
@@ -8,7 +8,7 @@ export const ServicesRow = () => {
             <div className="d-flex justify-content-around"> 
                 <div className="col-4 p-3">
                     <h1 className="text-start fw-normal fs-5 mb-3">PACKAGING</h1>
-                    <Link to={"/servicios"}>
+                    <Link to={"/companies/packaging"}>
                         <div className="imgcontainer border border-2" style={{height:'25vh', width: '100%'}}> 
                             <img className="imgservicios" src="packaging-sostenible.webp" alt="packaging" />
                         </div> 
@@ -16,7 +16,7 @@ export const ServicesRow = () => {
                 </div>
                 <div className="col-4 p-3">
                     <h1 className="text-start fw-normal fs-5 mb-3">TRANSPORTE</h1>
-                    <Link to={"/servicios"}>
+                    <Link to={"/companies/transporte"}>
                         <div className="imgcontainer border border-2" style={{height:'25vh', width: '100%'}}> 
                             <img className="imgservicios" src="furgonetas-w.webp" alt="packaging" />
                         </div> 
@@ -24,7 +24,7 @@ export const ServicesRow = () => {
                 </div>
                 <div className="col-4 p-3">
                     <h1 className="text-start fw-normal fs-5 mb-3">GESTIÓN DE RESIDUOS</h1>
-                    <Link to={"/servicios"}>
+                    <Link to={"/companies/gestion-de-residuos"}>
                         <div className="imgcontainer border border-2" style={{height:'25vh', width: '100%'}}> 
                             <img className="imgservicios" src="1533057826357.jpeg" alt="packaging" />
                         </div> 

--- a/src/front/js/component/servicesRow.js
+++ b/src/front/js/component/servicesRow.js
@@ -10,7 +10,7 @@ export const ServicesRow = () => {
                     <h1 className="text-start fw-normal fs-5 mb-3">PACKAGING</h1>
                     <Link to={"/companies/packaging"}>
                         <div className="imgcontainer border border-2" style={{height:'25vh', width: '100%'}}> 
-                            <img className="imgservicios" src="packaging-sostenible.webp" alt="packaging" />
+                            <img className="imgservicios" src="packaging-sostenible.webp" alt="img-packaging" />
                         </div> 
                     </Link>
                 </div>
@@ -18,7 +18,7 @@ export const ServicesRow = () => {
                     <h1 className="text-start fw-normal fs-5 mb-3">TRANSPORTE</h1>
                     <Link to={"/companies/transporte"}>
                         <div className="imgcontainer border border-2" style={{height:'25vh', width: '100%'}}> 
-                            <img className="imgservicios" src="furgonetas-w.webp" alt="packaging" />
+                            <img className="imgservicios" src="furgonetas-w.webp" alt="img-transporte" />
                         </div> 
                     </Link>
                 </div>
@@ -26,7 +26,7 @@ export const ServicesRow = () => {
                     <h1 className="text-start fw-normal fs-5 mb-3">GESTIÓN DE RESIDUOS</h1>
                     <Link to={"/companies/gestion-de-residuos"}>
                         <div className="imgcontainer border border-2" style={{height:'25vh', width: '100%'}}> 
-                            <img className="imgservicios" src="1533057826357.jpeg" alt="packaging" />
+                            <img className="imgservicios" src="1533057826357.jpeg" alt="img-gestion-residuos" />
                         </div> 
                     </Link>
                 </div>

--- a/src/front/js/layout.js
+++ b/src/front/js/layout.js
@@ -32,7 +32,7 @@ const Layout = () => {
                     <Routes>
                         <Route element={<Home />} path="/" />
                         <Route element={<Servicios />} path="/servicios" />
-                        <Route element={<Companies />} path="/companies" />
+                        <Route element={<Companies />} path="/companies/:paramId" />
                         <Route element={<Contacto />} path="/contacto" />
                         <Route element={<QuienesSomos />} path="/quienes-somos" />
                         <Route element={<InfoEmpresa />} path="/info-empresa" />

--- a/src/front/js/pages/companies.js
+++ b/src/front/js/pages/companies.js
@@ -2,12 +2,29 @@ import React, { useContext } from "react";
 import { Context } from "../store/appContext";
 import "../../styles/companies.css";
 import { CompanyCarousel } from "../component/companyCarousel";
+import { useParams } from "react-router-dom";
 
 export const Companies = () => {
     const { store } = useContext(Context);
+    const { paramId } = useParams();
+
+    const getSectorByParam = () => {
+        switch(paramId){
+            case 'packaging':
+                return 'Packaging';
+            case 'transporte':
+                return 'Transporte';
+            case 'gestion-de-residuos':
+                return 'Gestión de Residuos';
+            default:
+                console.log('El parametro recibido no es correcto.')
+                return undefined;
+        }
+    }
 
     const getSectorKeys = () => {
         if (store.companies && Object.keys(store.companies).length > 0) {
+            console.log(Object.keys(store.companies));
             return Object.keys(store.companies);
         }
         return [];
@@ -21,11 +38,20 @@ export const Companies = () => {
             {
                 store.companies && Object.keys(store.companies).length > 0 ? 
                 (
-                    getSectorKeys().map((sector, index) => ( 
-                        <div key={index} className="p-3">
-                            <CompanyCarousel sector={sector} />
+                    (getSectorByParam() !== undefined) ?
+                    (
+                        <div key={Date.now()} className="p-3">
+                            <CompanyCarousel sector={getSectorByParam()} />
                         </div>
-                    ))
+                    )
+                    :
+                    (
+                        getSectorKeys().map((sector, index) => ( 
+                            <div key={index} className="p-3">
+                                <CompanyCarousel sector={sector} />
+                            </div>
+                        ))
+                    )
                 ) 
                 : 
                 (

--- a/src/front/js/pages/companies.js
+++ b/src/front/js/pages/companies.js
@@ -41,14 +41,14 @@ export const Companies = () => {
                     (getSectorByParam() !== undefined) ?
                     (
                         <div key={Date.now()} className="p-3">
-                            <CompanyCarousel sector={getSectorByParam()} />
+                            <CompanyCarousel sector={getSectorByParam()} isGrid={true} />
                         </div>
                     )
                     :
                     (
                         getSectorKeys().map((sector, index) => ( 
                             <div key={index} className="p-3">
-                                <CompanyCarousel sector={sector} />
+                                <CompanyCarousel sector={sector} isGrid={false} />
                             </div>
                         ))
                     )

--- a/src/front/js/pages/servicios.js
+++ b/src/front/js/pages/servicios.js
@@ -5,11 +5,8 @@ import imgtransporte from "../../img/zepda-web-img/furgonetas-w.webp"
 import imgresiduos from "../../img/1533057826357.jpeg"
 import { Link } from "react-router-dom";
 
-
-
 export const Servicios = () => {
     const { store, actions } = useContext(Context);
-
 
     return (
         <>
@@ -31,7 +28,7 @@ export const Servicios = () => {
                 </div>
                 
                 </div>
-                <Link to="/companies"><button className="btn mb-2">Empresas</button></Link>
+                <Link to="/companies/packaging"><button className="btn mb-2">Empresas</button></Link>
                 
 
             </div>
@@ -52,7 +49,7 @@ export const Servicios = () => {
                 </div>
                 
                 </div>
-                <Link to="/companies"><button className="btn mb-2">Empresas</button></Link>
+                <Link to="/companies/transporte"><button className="btn mb-2">Empresas</button></Link>
                 
 
             </div>
@@ -75,7 +72,7 @@ export const Servicios = () => {
                 </div>
                 
                 </div>
-                <Link to="/companies"><button className="btn mb-2">Empresas</button></Link>
+                <Link to="/companies/gestion-de-residuos"><button className="btn mb-2">Empresas</button></Link>
                 
 
             </div>


### PR DESCRIPTION
La rama está medio mal nombrada...
Se ha creado la posibilidad de ver las empresas asociadas de forma clasificada por servicios, es decir, solo aparecen las del servicio seleccionado, esto se ha hecho usando el hook useParams y reutilizando la vista de página.
Además, se ha añadido la posibilidad de activar la vista en forma de Grid con un banner superior del tipo de servicio.